### PR TITLE
Use inputs library for Python joystick support

### DIFF
--- a/xInput2Serial/README.md
+++ b/xInput2Serial/README.md
@@ -19,7 +19,7 @@ The **XInput to Serial Converter** application maps controller inputs to a seria
 - Jamepad library for gamepad support
 - JNA library for interacting with native OS features
 - Python 3.10 or later (for the optional Python implementation)
- - `pyserial` and `pygame` libraries
+- `pyserial` and `inputs` libraries
  - `pywin32` on Windows if the `--window` option will be used
 
 #### Building the Package


### PR DESCRIPTION
## Summary
- migrate python version to use the `inputs` library
- add controller disconnect detection
- document new dependency

## Testing
- `python3 -m py_compile xInput2Serial/python_version/xinput2serial.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'usb')*

------
https://chatgpt.com/codex/tasks/task_e_6844691245d483259d4efb85883bf4d7